### PR TITLE
remove broken navigation links

### DIFF
--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -10,45 +10,5 @@ main:
     url: docs
   - title: "Certification"
     url: certs
-  
-
-ecad:
-  - title: Design
-    children:
-      - title: "KiCAD"
-        url: /ecad#kicad
-      - title: "Spice"
-        url: /ecad#spice
-
-mcad:
-  - title: Design
-    children:
-      - title: "FreeCAD"
-        url: /mcad#freecad
-      - title: "OpenSCAD"
-        url: /mcad#openscad
-
-mfg:
-  - title: Production Planning
-    children:
-      - title: "FreeCAD"
-        url: /mfg#freecad
-      - title: "OpenSCAD"
-        url: /mfg#openscad
-
-comm:
-  - title: Docs
-    children:
-      - title: "MKDocs"
-        url: /comm#mkdocs
-      - title: "OpenSCAD"
-        url: /comm#openscad
-
-  - title: Community
-    children:
-      - title: "Discord"
-        url: /comm#discord
-      - title: "Discourse"
-        url: /comm#discourse
 
 


### PR DESCRIPTION
The navigation.yaml file renders navigation sidebars for articles.

- This PR removes navigation sidebars for pages that no longer exist.
- It also removes the sidebar from the "Manufacturing" page. Manufacturing is the only page using article navigation sidebars, and the links are broken.


Before:
![Screenshot 2025-01-30 at 11-02-34 Manufacturing Tools - Midscale Manufacturing](https://github.com/user-attachments/assets/5a632c9b-8c0e-4d0f-bb99-61815c1111c3)

After:
![Screenshot 2025-01-30 at 11-02-19 Manufacturing Tools - Midscale Manufacturing](https://github.com/user-attachments/assets/f64c88a3-a30e-462c-9046-29078d4fe19f)
