### PR TITLE
Fix broken link to GitHub repo on homepage

### DIFF
--- a/index.md
+++ b/index.md
@@ -32,7 +32,7 @@ hero_text: " "
 
 ---
 
-### hardware.cafe is a [community driven](repo) resource for people shipping (or trying to ship) a hardware product.
+### hardware.cafe is a [community driven](https://github.com/opulo-inc/hardware.cafe/) resource for people shipping (or trying to ship) a hardware product.
 
 The site is broken into three parts:
 


### PR DESCRIPTION
I assume the "community-driven" link on the homepage is supposed to point to this repo, but it's a broken link right now (just goes to ``hardware.cafe/repo`` which is a 404). I just stumbled on that while exploring the site so now I'm submitting the least exciting PR of my entire career. 😎 